### PR TITLE
Fix the species filter dropdown

### DIFF
--- a/modules/EnsEMBL/Web/Component/Search/Results.pm
+++ b/modules/EnsEMBL/Web/Component/Search/Results.pm
@@ -136,8 +136,9 @@ sub _render_filter_dropdown {
     
   my $options;
   foreach (sort @$species) {
-    my $display_name = $species_defs->get_config($_, 'DISPLAY_NAME');
-    $options .= sprintf '<option value="%s">%s</option>\n', $display_name, $display_name;
+    my $display_name = $species_defs->get_config($_, 'SPECIES_DISPLAY_NAME');
+    my $production_name = $species_defs->get_config($_, 'SPECIES_PRODUCTION_NAME');
+    $options .= sprintf '<option value="%s">%s</option>\n', $production_name, $display_name;
   }
   
   return qq{

--- a/modules/EnsEMBL/Web/Controller/Psychic.pm
+++ b/modules/EnsEMBL/Web/Controller/Psychic.pm
@@ -211,10 +211,6 @@ sub psychic {
   if (!$flag) {
 ##EBEYE
     $species = 'all' if (lc($species) eq 'multi' or $site_type eq 'ensemblunit');
-    if ($species and lc($species) ne 'all') {
-      $species = $species_defs->get_config($species, 'SPECIES_COMMON_NAME');
-      $species =~ s/(\[|\])//g;
-    }
 ##EBEYE
 
     $url = $self->escaped_url(($species eq 'ALL' || !$species ? '/Multi' : $species_path) . "/$script?species=%s;idx=%s;q=%s", $species || 'all', $index, $query);

--- a/modules/EnsEMBL/Web/Document/HTML/HomeSearch.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/HomeSearch.pm
@@ -93,7 +93,7 @@ sub _add_species_dropdown {
   my $hub          = $self->hub;
   my $species_defs = $hub->species_defs;
   my $favourites   = $hub->get_favourite_species;
-  my %species      = map { $species_defs->get_config($_, 'DISPLAY_NAME') => $_ } @{$species_defs->multi_hash->{'ENSEMBL_DATASETS'}};
+  my %species      = map { $species_defs->get_config($_, 'SPECIES_DISPLAY_NAME') => $_ } @{$species_defs->multi_hash->{'ENSEMBL_DATASETS'}};
   my %common_names = reverse %species;
 
   $field->add_element({

--- a/modules/EnsEMBL/Web/EBeyeSearch.pm
+++ b/modules/EnsEMBL/Web/EBeyeSearch.pm
@@ -79,28 +79,12 @@ sub current_sitename {
   return $SiteDefs::EBEYE_SITE_NAMES->{lc($self->current_unit)} || $self->current_unit;
 }
 
-sub production_name {
-  my ($self, $display_name) = @_;
-  
-  my $display_names = $self->hub->species_defs->{'SPECIES_DISPLAY_NAME'};
-  
-  my $production_name;
-  foreach my $key (keys %$display_names) {
-    if ($display_names->{$key} eq $display_name) {
-      $production_name = $key;
-      last;
-    }
-  } 
-
-  return $production_name;
-}
-
 sub ebeye_query {
   my ($self, $no_genomic_unit) = @_;
-  
+
   my @parts;
   push @parts, $self->query_term;
-  push @parts, 'system_name:' . $self->production_name($self->species) if $self->species ne 'all';
+  push @parts, 'system_name:' . $self->species if $self->species ne 'all';
   push @parts, 'collection:' . $self->collection if $self->collection ne 'all';
   
   return join ' AND ', @parts;
@@ -113,7 +97,6 @@ sub pager {
   $pager->total_entries($self->hit_count > 10000 ? 10000 : $self->hit_count);
   $pager->entries_per_page($page_size || 10);
   $pager->current_page($self->current_page);
-  
   return $pager; 
 }
 

--- a/modules/EnsEMBL/Web/EBeyeSearch.pm
+++ b/modules/EnsEMBL/Web/EBeyeSearch.pm
@@ -82,7 +82,7 @@ sub current_sitename {
 sub production_name {
   my ($self, $display_name) = @_;
   
-  my $display_names = $self->hub->species_defs->SPECIES_DISPLAY_NAME;
+  my $display_names = $self->hub->species_defs->{'SPECIES_DISPLAY_NAME'};
   
   my $production_name;
   foreach my $key (keys %$display_names) {
@@ -127,7 +127,7 @@ sub hit_count {
     my $query = sprintf("%s AND genomic_unit:%s AND system_name:%s",
       $self->ebeye_query,
       $self->current_unit,
-      $self->production_name($self->filter_species),
+      $self->filter_species,
     );
     my $index = $self->current_index;
     return $self->{_hit_count} = $self->rest->get_results_count("ensemblGenomes_$index", $query) || 0;
@@ -222,7 +222,7 @@ sub get_gene_hits {
   my @multi_fields   = qw(transcript gene_synonym genetree);
   my $query          = $self->ebeye_query;
      $query         .= " AND genomic_unit:$unit" if $unit ne 'ensembl';
-     $query         .= " AND system_name:" . $self->production_name($filter_species) if $filter_species;
+     $query         .= " AND system_name:" . $filter_species if $filter_species;
 
   my $hits = $self->rest->get_results_as_hashes($domain, $query, 
     {
@@ -263,7 +263,7 @@ sub get_seq_region_hits {
   my @fields         = qw(id name species production_name location coord_system genomic_unit);
   my $query          = $self->ebeye_query;
      $query         .= " AND genomic_unit:$unit" if $unit ne 'ensembl';
-     $query         .= " AND system_name:" . $self->production_name($filter_species) if $filter_species;
+     $query         .= " AND system_name:" . $filter_species if $filter_species;
 
   my $hits = $self->rest->get_results_as_hashes('ensemblGenomes_seqregion', $query, 
     {
@@ -326,7 +326,7 @@ sub get_variant_hits {
   my @multi_fields   = qw(synonym associated_gene phenotype study);
   my $query          = $self->ebeye_query;
      $query         .= " AND genomic_unit:$unit" if $unit ne 'ensembl';
-     $query         .= " AND system_name:" . $self->production_name($filter_species) if $filter_species;
+     $query         .= " AND system_name:" . $filter_species if $filter_species;
 
 
   my $hits = $self->rest->get_results_as_hashes('ensemblGenomes_variant', $query, 


### PR DESCRIPTION
## Bug
If you do a search on any eg site, you will see a dropdown filter that's supposed to restrict search results to a single species. The dropdown in production currently looks like this:

<img src="https://user-images.githubusercontent.com/6834224/91460578-dc231a00-e87f-11ea-9003-6712d3e2da55.png" width=600/>

## Causes
There are various problems related to this bug; and the old age of the code suggests that it has been present for a while:
- `modules/EnsEMBL/Web/Component/Search/Results.pm` is using the `DISPLAY_NAME` key, while the correct key, presumably, is `SPECIES_DISPLAY_NAME`
- After the `DISPLAY_NAME` was replaced with the `SPECIES_DISPLAY_NAME`, it turned out that the filter adds species display name to the url; and then in the `EBeyeSearch.pm` module tries to get species production name back from the display name.  For whatever reason, this didn't work; so I changed display name in the url to production name. Don't know if things are going to break because of that.

## Sandbox
http://ves-hx2-76.ebi.ac.uk:8450/Multi/Search/Results?q=PAD4;species=all;collection=all;site=ensemblthis

## Remaining Problems
- The `production_name` function still remains in the `EBeyeSearch.pm` module and is being used by the `ebeye_query` function. Don't know if it works at all.
- ~The `DISPLAY_NAME` key is still used in the `modules/EnsEMBL/Web/Document/HTML/HomeSearch.pm` module. I do not know whether this part of the code works either.~